### PR TITLE
Add in-memory caching for IDs to check duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,29 @@ Just run `forwarder --help` to get the latest help
 usage: forwarder --env-alias=ENV-ALIAS --redis.server=REDIS.SERVER --redis.password=REDIS.PASSWORD --sumologic.url=SUMOLOGIC.URL [<flags>]
 
 Flags:
-  --help                         Show context-sensitive help (also try --help-long and --help-man).
-  --env-alias=ENV-ALIAS          Environment alias use for Prometheus metrics(qa,prod,...)
-  --redis.server=REDIS.SERVER    Redis server address
-  --redis.password=REDIS.PASSWORD
-                                 Password for Redis
-  --redis.slowlog=100            Numbers of SlowLog to fetch (default 100)
-  --query-interval=10s           Redis SlowLog interval Query
-  --dups-cache-ttl=60s      Interval which duplicate cache is cleared
-  --sumologic.url=SUMOLOGIC.URL  SumoLogic Collector URL as give by SumoLogic
-  --sumologic.source.category=""
-                                 Override default Source Category
-  --sumologic.source.name=""     Override default Source Name
-  --sumologic.source.host=""     Override default Source Host
-  --web.listen-address=":9121"   Address to listen on for web interface and telemetry.
-  --web.telemetry-path="/metrics"
-                                 Path under which to expose metrics.
-  --version                      Show application version.
+      --help                 Show context-sensitive help (also try --help-long and --help-man).
+      --env-alias=ENV-ALIAS  Environment alias use for Prometheus metrics(qa,prod,...)
+      --redis.server=REDIS.SERVER
+                             Redis server address
+      --redis.password=REDIS.PASSWORD
+                             Password for Redis
+      --redis.slowlog=100    Numbers of SlowLog to fetch (default 100)
+      --query-interval=10s   Redis SlowLog interval Query
+      --dups-cache-ttl=60s   Interval which duplicate cache is cleared
+      --sumologic.url=SUMOLOGIC.URL
+                             SumoLogic Collector URL as give by SumoLogic
+      --sumologic.source.category=""
+                             Override default Source Category
+      --sumologic.source.name=""
+                             Override default Source Name
+      --sumologic.source.host=""
+                             Override default Source Host
+      --web.listen-address=":9121"
+                             Address to listen on for web interface and telemetry.
+      --web.telemetry-path="/metrics"
+                             Path under which to expose metrics.
+  -l, --log=ERROR... ...     Log levels: -l TRACE -l INFO -l WARNING -l ERROR
+      --version              Show application version.
 ```
 ## Environment Variable
 This application support Environment variable only for

--- a/README.md
+++ b/README.md
@@ -8,21 +8,26 @@ This tool use Go modules and is compiled with Go 1.11.X
 Just run `forwarder --help` to get the latest help
 
 ```bash
-usage: forwarder --redis-server=REDIS-SERVER --redis-password=REDIS-PASSWORD --sumologic-url=SUMOLOGIC-URL [<flags>]
+usage: forwarder --env-alias=ENV-ALIAS --redis.server=REDIS.SERVER --redis.password=REDIS.PASSWORD --sumologic.url=SUMOLOGIC.URL [<flags>]
 
 Flags:
   --help                         Show context-sensitive help (also try --help-long and --help-man).
-  --redis-server=REDIS-SERVER    Redis server address
-  --redis-password=REDIS-PASSWORD
+  --env-alias=ENV-ALIAS          Environment alias use for Prometheus metrics(qa,prod,...)
+  --redis.server=REDIS.SERVER    Redis server address
+  --redis.password=REDIS.PASSWORD
                                  Password for Redis
+  --redis.slowlog=100            Numbers of SlowLog to fetch (default 100)
   --query-interval=10s           Redis SlowLog interval Query
-  --sumologic-url=SUMOLOGIC-URL  SumoLogic Collector URL as give by SumoLogic
-  --sumologic-source-category=""
+  --dups-clear-interval=60s      Interval which duplicate cache is cleared
+  --sumologic.url=SUMOLOGIC.URL  SumoLogic Collector URL as give by SumoLogic
+  --sumologic.source.category=""
                                  Override default Source Category
-  --sumologic-source-name=""     Override default Source Name
-  --sumologic-source-host=""     Override default Source Host
+  --sumologic.source.name=""     Override default Source Name
+  --sumologic.source.host=""     Override default Source Host
+  --web.listen-address=":9121"   Address to listen on for web interface and telemetry.
+  --web.telemetry-path="/metrics"
+                                 Path under which to expose metrics.
   --version                      Show application version.
-
 ```
 ## Environment Variable
 This application support Environment variable only for

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ go test ./... -mod=vendor -v
 
 
 ## Todo
-  [] Add Buffer to avoid to much pressure
-  [] Put retrieve/sending into GoRoutine
-  [] More test coverage
-  [] Dedup. before sending SumoLogic
+
+  - [x] Add Buffer to avoid to much pressure  
+  - [ ] Put retrieve/sending into GoRoutine  
+  - [ ] More test coverage  
+  - [x] Dedup. before sending SumoLogic  

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Flags:
                                  Password for Redis
   --redis.slowlog=100            Numbers of SlowLog to fetch (default 100)
   --query-interval=10s           Redis SlowLog interval Query
-  --dups-clear-interval=60s      Interval which duplicate cache is cleared
+  --dups-cache-ttl=60s      Interval which duplicate cache is cleared
   --sumologic.url=SUMOLOGIC.URL  SumoLogic Collector URL as give by SumoLogic
   --sumologic.source.category=""
                                  Override default Source Category

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -32,6 +33,9 @@ var (
 	sSourceHost      = kingpin.Flag("sumologic.source.host", "Override default Source Host").Default("").String()
 	listenAddress    = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9121").String()
 	metricPath       = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+
+	logs     = kingpin.Flag("log", logsHelp).Short('l').Default(logging.LevelsInSlice[3], logging.LevelsInSlice[1]).Enums(logging.LevelsInSlice[0:]...)
+	logsHelp = fmt.Sprintf("Log levels: -l %s", strings.Join(logging.LevelsInSlice[0:], " -l "))
 )
 
 const (
@@ -46,11 +50,11 @@ var (
 )
 
 func main() {
-	//logging init
-	logging.Init(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr)
-
 	kingpin.Version(version)
 	kingpin.Parse()
+
+	//logging init
+	logging.Init(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr, logging.SliceToLevels(*logs))
 
 	//Connect to redis server
 	rConnection, err := redis.Dial("tcp", *rAddr,

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -25,7 +25,7 @@ var (
 	rPassword        = kingpin.Flag("redis.password", "Password for Redis").Required().Envar("REDIS_PASSWORD").String()
 	rsizeSlowLog     = kingpin.Flag("redis.slowlog", "Numbers of SlowLog to fetch (default 100)").Envar("REDIS_SLOWLOG").Default("100").Int()
 	qInterval        = kingpin.Flag("query-interval", "Redis SlowLog interval Query").Envar("SUMOLOGIC_QUERY_INT").Default("10s").Duration()
-	dupClearInterval = kingpin.Flag("dups-clear-interval", "Interval which duplicate cache is cleared").Envar("SUMOLOGIC_QUERY_INT").Default("60s").Duration()
+	dupClearInterval = kingpin.Flag("dups-cache-ttl", "Interval which duplicate cache is cleared").Envar("SUMOLOGIC_QUERY_INT").Default("60s").Duration()
 	sURL             = kingpin.Flag("sumologic.url", "SumoLogic Collector URL as give by SumoLogic").Required().Envar("SUMOLOGIC_URL").String()
 	sSourceCategory  = kingpin.Flag("sumologic.source.category", "Override default Source Category").Envar("SUMOLOGIC_CAT").Default("").String()
 	sSourceName      = kingpin.Flag("sumologic.source.name", "Override default Source Name").Default("").String()

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -20,17 +20,18 @@ import (
 )
 
 var (
-	alias           = kingpin.Flag("env-alias", "Environment alias use for Prometheus metrics(qa,prod,...)").Envar("ENV_ALIAS").Required().String()
-	rAddr           = kingpin.Flag("redis.server", "Redis server address").Required().Envar("REDIS_SERVER").String()
-	rPassword       = kingpin.Flag("redis.password", "Password for Redis").Required().Envar("REDIS_PASSWORD").String()
-	rsizeSlowLog    = kingpin.Flag("redis.slowlog", "Numbers of SlowLog to fetch (default 100)").Envar("REDIS_SLOWLOG").Default("100").Int()
-	qInterval       = kingpin.Flag("query-interval", "Redis SlowLog interval Query").Envar("SUMOLOGIC_QUERY_INT").Default("10s").Duration()
-	sURL            = kingpin.Flag("sumologic.url", "SumoLogic Collector URL as give by SumoLogic").Required().Envar("SUMOLOGIC_URL").String()
-	sSourceCategory = kingpin.Flag("sumologic.source.category", "Override default Source Category").Envar("SUMOLOGIC_CAT").Default("").String()
-	sSourceName     = kingpin.Flag("sumologic.source.name", "Override default Source Name").Default("").String()
-	sSourceHost     = kingpin.Flag("sumologic.source.host", "Override default Source Host").Default("").String()
-	listenAddress   = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9121").String()
-	metricPath      = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+	alias            = kingpin.Flag("env-alias", "Environment alias use for Prometheus metrics(qa,prod,...)").Envar("ENV_ALIAS").Required().String()
+	rAddr            = kingpin.Flag("redis.server", "Redis server address").Required().Envar("REDIS_SERVER").String()
+	rPassword        = kingpin.Flag("redis.password", "Password for Redis").Required().Envar("REDIS_PASSWORD").String()
+	rsizeSlowLog     = kingpin.Flag("redis.slowlog", "Numbers of SlowLog to fetch (default 100)").Envar("REDIS_SLOWLOG").Default("100").Int()
+	qInterval        = kingpin.Flag("query-interval", "Redis SlowLog interval Query").Envar("SUMOLOGIC_QUERY_INT").Default("10s").Duration()
+	dupClearInterval = kingpin.Flag("dups-clear-interval", "Interval which duplicate cache is cleared").Envar("SUMOLOGIC_QUERY_INT").Default("60s").Duration()
+	sURL             = kingpin.Flag("sumologic.url", "SumoLogic Collector URL as give by SumoLogic").Required().Envar("SUMOLOGIC_URL").String()
+	sSourceCategory  = kingpin.Flag("sumologic.source.category", "Override default Source Category").Envar("SUMOLOGIC_CAT").Default("").String()
+	sSourceName      = kingpin.Flag("sumologic.source.name", "Override default Source Name").Default("").String()
+	sSourceHost      = kingpin.Flag("sumologic.source.host", "Override default Source Host").Default("").String()
+	listenAddress    = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9121").String()
+	metricPath       = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 )
 
 const (
@@ -63,7 +64,7 @@ func main() {
 		os.Exit(ExitCodeError)
 	}
 
-	r := slowlog.NewSlowLog(rConnection)
+	r := slowlog.NewSlowLog(rConnection, *dupClearInterval)
 	sClient := sumologic.NewSumoLogic(
 		*sURL,
 		*sSourceHost,

--- a/logging/helpers.go
+++ b/logging/helpers.go
@@ -1,0 +1,24 @@
+package logging
+
+var (
+	// LevelsInSlice levels in string format
+	LevelsInSlice = [...]string{"TRACE", "INFO", "WARNING", "ERROR"}
+)
+
+// SliceToLevels convert levels in slice to a LogLevel
+func SliceToLevels(sl []string) int {
+	lvl := 0
+	for _, s := range sl {
+		switch s {
+		case LevelsInSlice[0]:
+			lvl = lvl | LogTrace
+		case LevelsInSlice[1]:
+			lvl = lvl | LogInfo
+		case LevelsInSlice[2]:
+			lvl = lvl | LogWarning
+		case LevelsInSlice[3]:
+			lvl = lvl | LogError
+		}
+	}
+	return lvl
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -2,9 +2,19 @@ package logging
 
 import (
 	"io"
+	"io/ioutil"
 	"log"
 )
 
+// logging levels
+const (
+	LogTrace int = 1 << iota
+	LogInfo
+	LogWarning
+	LogError
+)
+
+// logging interfaces
 var (
 	Trace   *log.Logger
 	Info    *log.Logger
@@ -12,12 +22,29 @@ var (
 	Error   *log.Logger
 )
 
+// Init initialize the loggers with their buffers
 func Init(
 	traceHandle io.Writer,
 	infoHandle io.Writer,
 	warningHandle io.Writer,
-	errorHandle io.Writer) {
+	errorHandle io.Writer,
+	logLevel int) {
 
+	// check if logger level is specified, if not, replace buffer with discard
+	if logLevel&(LogTrace) == 0 {
+		traceHandle = ioutil.Discard
+	}
+	if logLevel&(LogInfo) == 0 {
+		infoHandle = ioutil.Discard
+	}
+	if logLevel&(LogWarning) == 0 {
+		warningHandle = ioutil.Discard
+	}
+	if logLevel&(LogError) == 0 {
+		errorHandle = ioutil.Discard
+	}
+
+	// initialize loggers
 	Trace = log.New(traceHandle,
 		"TRACE: ",
 		log.Ldate|log.Ltime|log.Lshortfile)

--- a/slowlog/slowlog_test.go
+++ b/slowlog/slowlog_test.go
@@ -3,12 +3,13 @@ package slowlog
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/rafaeljusto/redigomock"
 )
 
 var (
-	slowlogResult = []interface{}{
+	slowlogResult1 = []interface{}{
 		[]interface{}{
 			int64(950),
 			int64(1483706756),
@@ -27,6 +28,16 @@ var (
 				[]uint8("CONFIG"),
 				[]uint8("GET"),
 				[]uint8("slowlog-max-len"),
+			},
+		},
+		[]interface{}{
+			int64(950),
+			int64(1483706756),
+			int64(144),
+			[]interface{}{
+				[]uint8("SLOWLOG"),
+				[]uint8("GET"),
+				[]uint8("128"),
 			},
 		},
 		[]interface{}{
@@ -57,6 +68,96 @@ var (
 				[]uint8("slowlog-max-len"),
 			},
 		},
+		[]interface{}{
+			int64(949),
+			int64(1483706756),
+			int64(13),
+			[]interface{}{
+				[]uint8("CONFIG"),
+				[]uint8("GET"),
+				[]uint8("slowlog-max-len"),
+			},
+		},
+	}
+
+	slowlogResult2 = []interface{}{
+		[]interface{}{
+			int64(950),
+			int64(1483706756),
+			int64(144),
+			[]interface{}{
+				[]uint8("SLOWLOG"),
+				[]uint8("GET"),
+				[]uint8("128"),
+			},
+		},
+		[]interface{}{
+			int64(952),
+			int64(1483706756),
+			int64(65),
+			[]interface{}{
+				[]uint8("INFO"),
+			},
+		},
+		[]interface{}{
+			int64(951),
+			int64(1483706717),
+			int64(30),
+			[]interface{}{
+				[]uint8("CONFIG"),
+				[]uint8("GET"),
+			},
+		},
+		[]interface{}{
+			int64(949),
+			int64(1483706756),
+			int64(13),
+			[]interface{}{
+				[]uint8("CONFIG"),
+				[]uint8("GET"),
+				[]uint8("slowlog-max-len"),
+			},
+		},
+	}
+
+	slowlogResult3 = []interface{}{
+		[]interface{}{
+			int64(953),
+			int64(1483706756),
+			int64(13),
+			[]interface{}{
+				[]uint8("CONFIG"),
+				[]uint8("GET"),
+				[]uint8("slowlog-max-len"),
+			},
+		},
+		[]interface{}{
+			int64(950),
+			int64(1483706756),
+			int64(144),
+			[]interface{}{
+				[]uint8("SLOWLOG"),
+				[]uint8("GET"),
+				[]uint8("128"),
+			},
+		},
+		[]interface{}{
+			int64(952),
+			int64(1483706756),
+			int64(65),
+			[]interface{}{
+				[]uint8("INFO"),
+			},
+		},
+		[]interface{}{
+			int64(951),
+			int64(1483706717),
+			int64(30),
+			[]interface{}{
+				[]uint8("CONFIG"),
+				[]uint8("GET"),
+			},
+		},
 	}
 )
 
@@ -64,7 +165,7 @@ func TestNewRedis(t *testing.T) {
 	conn := redigomock.NewConn()
 	cmd := conn.Command("PING").Expect(string("PONG"))
 
-	sl := NewSlowLog(conn)
+	sl := NewSlowLog(conn, 60*time.Second)
 	if ping := sl.Ping(); ping != true {
 		t.Fatalf("Command (%v) return (%v) ", cmd.Name, ping)
 	}
@@ -72,8 +173,8 @@ func TestNewRedis(t *testing.T) {
 
 func TestFetchSlowLog(t *testing.T) {
 	conn := redigomock.NewConn()
-	cmd := conn.Command("SLOWLOG", "GET", 100).Expect(slowlogResult)
-	sl := NewSlowLog(conn)
+	cmd := conn.Command("SLOWLOG", "GET", 100).Expect(slowlogResult1)
+	sl := NewSlowLog(conn, 60*time.Second)
 	result, err := sl.FetchSlowLog(100)
 	fmt.Println(conn.Stats(cmd))
 	if err != nil {
@@ -82,4 +183,29 @@ func TestFetchSlowLog(t *testing.T) {
 	if len(result) != 5 {
 		t.Fatalf("Expected SlOWLOG to return %v result", 5)
 	}
+}
+func TestFetchSlowLogMultiple(t *testing.T) {
+	conn := redigomock.NewConn()
+	cacheReset := 2 * time.Second
+	sl := NewSlowLog(conn, cacheReset)
+
+	// make this reusable in this test context
+	fn := func(expectedCount int, slowlogResult []interface{}) {
+		cmd := conn.Command("SLOWLOG", "GET", 100).Expect(slowlogResult)
+		result, err := sl.FetchSlowLog(100)
+		fmt.Println(conn.Stats(cmd))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if l := len(result); l != expectedCount {
+			t.Fatalf("Expected SlOWLOG to return %v result, got %v", expectedCount, l)
+		}
+	}
+	// cache should work
+	fn(5, slowlogResult1)
+	fn(0, slowlogResult1)
+	// cache should have reset
+	time.Sleep(cacheReset + (1 * time.Second))
+	fn(4, slowlogResult2)
+	fn(1, slowlogResult3)
 }


### PR DESCRIPTION
Cache will invalidate every `--dups-cache-ttl=60s` (command option)
To enable logs, use `--log=WARNING` or `-l WARNING -l INFO` (command option)